### PR TITLE
Add MySQL table prefix support

### DIFF
--- a/src/main/java/me/danjono/inventoryrollback/config/ConfigData.java
+++ b/src/main/java/me/danjono/inventoryrollback/config/ConfigData.java
@@ -77,6 +77,7 @@ public class ConfigData {
     private static String mysqlHost;
     private static int mysqlPort;
     private static String mysqlDatabase;
+    private static String mysqlPrefix;
     private static String mysqlUsername;
     private static String mysqlPassword;
     private static boolean mysqlUseSSL;
@@ -122,6 +123,7 @@ public class ConfigData {
         setMySQLHost((String) getDefaultValue("mysql.details.host", "127.0.0.1"));
         setMySQLPort((int) getDefaultValue("mysql.details.port", 3306));
         setMySQLDatabase((String) getDefaultValue("mysql.details.database", "inventory_rollback"));
+        setMySQLPrefix((String) getDefaultValue("mysql.details.prefix", ""));
         setMySQLUsername((String) getDefaultValue("mysql.details.username", "username"));
         setMySQLPassword((String) getDefaultValue("mysql.details.password", "password"));
         setMySQLUseSSL((boolean) getDefaultValue("mysql.details.use-SSL", true));
@@ -173,6 +175,10 @@ public class ConfigData {
 
     public static void setMySQLDatabase(String value) {
         mysqlDatabase = value;
+    }
+
+    public static void setMySQLPrefix(String value) {
+        mysqlPrefix = value;
     }
 
     public static void setMySQLUsername(String value) {
@@ -281,6 +287,10 @@ public class ConfigData {
 
     public static String getMySQLDatabase() {
         return mysqlDatabase;
+    }
+
+    public static String getMySQLPrefix() {
+        return mysqlPrefix;
     }
 
     public static String getMySQLUsername() {

--- a/src/main/java/me/danjono/inventoryrollback/config/ConfigData.java
+++ b/src/main/java/me/danjono/inventoryrollback/config/ConfigData.java
@@ -77,7 +77,7 @@ public class ConfigData {
     private static String mysqlHost;
     private static int mysqlPort;
     private static String mysqlDatabase;
-    private static String mysqlPrefix;
+    private static String mysqlTablePrefix;
     private static String mysqlUsername;
     private static String mysqlPassword;
     private static boolean mysqlUseSSL;
@@ -123,7 +123,7 @@ public class ConfigData {
         setMySQLHost((String) getDefaultValue("mysql.details.host", "127.0.0.1"));
         setMySQLPort((int) getDefaultValue("mysql.details.port", 3306));
         setMySQLDatabase((String) getDefaultValue("mysql.details.database", "inventory_rollback"));
-        setMySQLPrefix((String) getDefaultValue("mysql.details.prefix", "backup_"));
+        setMySQLTablePrefix((String) getDefaultValue("mysql.details.table-prefix", "backup_"));
         setMySQLUsername((String) getDefaultValue("mysql.details.username", "username"));
         setMySQLPassword((String) getDefaultValue("mysql.details.password", "password"));
         setMySQLUseSSL((boolean) getDefaultValue("mysql.details.use-SSL", true));
@@ -177,8 +177,8 @@ public class ConfigData {
         mysqlDatabase = value;
     }
 
-    public static void setMySQLPrefix(String value) {
-        mysqlPrefix = value;
+    public static void setMySQLTablePrefix(String value) {
+        mysqlTablePrefix = value;
     }
 
     public static void setMySQLUsername(String value) {
@@ -289,8 +289,8 @@ public class ConfigData {
         return mysqlDatabase;
     }
 
-    public static String getMySQLPrefix() {
-        return mysqlPrefix;
+    public static String getMySQLTablePrefix() {
+        return mysqlTablePrefix;
     }
 
     public static String getMySQLUsername() {

--- a/src/main/java/me/danjono/inventoryrollback/config/ConfigData.java
+++ b/src/main/java/me/danjono/inventoryrollback/config/ConfigData.java
@@ -123,7 +123,7 @@ public class ConfigData {
         setMySQLHost((String) getDefaultValue("mysql.details.host", "127.0.0.1"));
         setMySQLPort((int) getDefaultValue("mysql.details.port", 3306));
         setMySQLDatabase((String) getDefaultValue("mysql.details.database", "inventory_rollback"));
-        setMySQLPrefix((String) getDefaultValue("mysql.details.prefix", ""));
+        setMySQLPrefix((String) getDefaultValue("mysql.details.prefix", "backup_"));
         setMySQLUsername((String) getDefaultValue("mysql.details.username", "username"));
         setMySQLPassword((String) getDefaultValue("mysql.details.password", "password"));
         setMySQLUseSSL((boolean) getDefaultValue("mysql.details.use-SSL", true));

--- a/src/main/java/me/danjono/inventoryrollback/data/MySQL.java
+++ b/src/main/java/me/danjono/inventoryrollback/data/MySQL.java
@@ -28,11 +28,11 @@ public class MySQL {
     private BackupTable backupTable;
 
     public enum BackupTable {
-        DEATH(ConfigData.getMySQLPrefix() + "deaths"),
-        JOIN(ConfigData.getMySQLPrefix() + "joins"),
-        QUIT(ConfigData.getMySQLPrefix() + "quits"),
-        WORLD_CHANGE(ConfigData.getMySQLPrefix() + "world_changes"),
-        FORCE(ConfigData.getMySQLPrefix() + "force_backups");
+        DEATH(ConfigData.getMySQLTablePrefix() + "deaths"),
+        JOIN(ConfigData.getMySQLTablePrefix() + "joins"),
+        QUIT(ConfigData.getMySQLTablePrefix() + "quits"),
+        WORLD_CHANGE(ConfigData.getMySQLTablePrefix() + "world_changes"),
+        FORCE(ConfigData.getMySQLTablePrefix() + "force_backups");
 
         private final String tableName;
 

--- a/src/main/java/me/danjono/inventoryrollback/data/MySQL.java
+++ b/src/main/java/me/danjono/inventoryrollback/data/MySQL.java
@@ -28,11 +28,11 @@ public class MySQL {
     private BackupTable backupTable;
 
     public enum BackupTable {
-        DEATH(ConfigData.getMySQLPrefix() + "backup_deaths"),
-        JOIN(ConfigData.getMySQLPrefix() + "backup_joins"),
-        QUIT(ConfigData.getMySQLPrefix() + "backup_quits"),
-        WORLD_CHANGE(ConfigData.getMySQLPrefix() + "backup_world_changes"),
-        FORCE(ConfigData.getMySQLPrefix() + "backup_force_backups");
+        DEATH(ConfigData.getMySQLPrefix() + "deaths"),
+        JOIN(ConfigData.getMySQLPrefix() + "joins"),
+        QUIT(ConfigData.getMySQLPrefix() + "quits"),
+        WORLD_CHANGE(ConfigData.getMySQLPrefix() + "world_changes"),
+        FORCE(ConfigData.getMySQLPrefix() + "force_backups");
 
         private final String tableName;
 

--- a/src/main/java/me/danjono/inventoryrollback/data/MySQL.java
+++ b/src/main/java/me/danjono/inventoryrollback/data/MySQL.java
@@ -28,11 +28,11 @@ public class MySQL {
     private BackupTable backupTable;
 
     public enum BackupTable {
-        DEATH("backup_deaths"),
-        JOIN("backup_joins"),
-        QUIT("backup_quits"),
-        WORLD_CHANGE("backup_world_changes"),
-        FORCE("backup_force_backups");
+        DEATH(ConfigData.getMySQLPrefix() + "backup_deaths"),
+        JOIN(ConfigData.getMySQLPrefix() + "backup_joins"),
+        QUIT(ConfigData.getMySQLPrefix() + "backup_quits"),
+        WORLD_CHANGE(ConfigData.getMySQLPrefix() + "backup_world_changes"),
+        FORCE(ConfigData.getMySQLPrefix() + "backup_force_backups");
 
         private final String tableName;
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,6 +23,7 @@ mysql:
     host: 'localhost'
     port: 3306
     database: 'inventory_rollback'
+    prefix: ''
     username: 'username'
     password: 'password'
     use-SSL: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,7 +23,7 @@ mysql:
     host: 'localhost'
     port: 3306
     database: 'inventory_rollback'
-    prefix: 'backup_'
+    table-prefix: 'backup_'
     username: 'username'
     password: 'password'
     use-SSL: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,7 +23,7 @@ mysql:
     host: 'localhost'
     port: 3306
     database: 'inventory_rollback'
-    prefix: ''
+    prefix: 'backup_'
     username: 'username'
     password: 'password'
     use-SSL: true


### PR DESCRIPTION
This adds MySQL table prefix support and the corresponding option in `config.yml` (defaults to `backup_` to preserve backwards compatibility).

Closes #16 