### PR TITLE
Add multi-server support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.nuclyon.technicallycoded.inventoryrollback</groupId>
     <artifactId>InventoryRollbackPlus</artifactId>
-    <version>1.7.6</version>
+    <version>1.7.7-custom</version>
     <packaging>jar</packaging>
     <name>InventoryRollbackPlus</name>
     <url>https://github.com/TechnicallyCoded/Inventory-Rollback-Plus/</url>
@@ -64,13 +64,13 @@
             <systemPath>${project.basedir}/lib/spigot-1.19.3.jar</systemPath>
             <optional>true</optional>
         </dependency>-->
-        <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot</artifactId>
-            <version>1.20.5-R0.1-SNAPSHOT</version>
-            <optional>true</optional>
-            <scope>provided</scope>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.spigotmc</groupId>-->
+<!--            <artifactId>spigot</artifactId>-->
+<!--            <version>1.20.5-R0.1-SNAPSHOT</version>-->
+<!--            <optional>true</optional>-->
+<!--            <scope>provided</scope>-->
+<!--        </dependency>-->
         <!-- bStats API -->
         <dependency>
             <groupId>org.bstats</groupId>

--- a/src/main/java/com/nuclyon/technicallycoded/inventoryrollback/InventoryRollbackPlus.java
+++ b/src/main/java/com/nuclyon/technicallycoded/inventoryrollback/InventoryRollbackPlus.java
@@ -91,6 +91,9 @@ public class InventoryRollbackPlus extends InventoryRollback {
         // Run after all plugin enable
         getServer().getScheduler().runTask(this, EventLogs::patchLowestHandlers);
 
+        //register bungeecord messaging channel
+        getServer().getMessenger().registerOutgoingPluginChannel(InventoryRollback.getInstance(), "BungeeCord");
+
         // PaperLib
         if (!PaperLib.isPaper()) {
             this.getLogger().info("----------------------------------------");
@@ -122,6 +125,9 @@ public class InventoryRollbackPlus extends InventoryRollback {
 
         // Unregister event listeners
         HandlerList.unregisterAll(this);
+
+        //register bungeecord messaging channel
+        getServer().getMessenger().unregisterOutgoingPluginChannel(InventoryRollback.getInstance(), "BungeeCord");
 
         // Cancel tasks
         this.getServer().getScheduler().cancelTasks(this);

--- a/src/main/java/me/danjono/inventoryrollback/config/ConfigData.java
+++ b/src/main/java/me/danjono/inventoryrollback/config/ConfigData.java
@@ -82,6 +82,7 @@ public class ConfigData {
     private static boolean mysqlVerifyCertificate;
     private static boolean mysqlPubKeyRetrieval;
 
+    private static String serverName;
     private static boolean allowOtherPluginEditDeathInventory;
     private static boolean restoreToPlayerButton;
     private static int backupLinesVisible;
@@ -130,7 +131,9 @@ public class ConfigData {
         setMySQLPassword((String) getDefaultValue("mysql.details.password", "password"));
         setMySQLUseSSL((boolean) getDefaultValue("mysql.details.use-SSL", true));
         setMySQLVerifyCertificate((boolean) getDefaultValue("mysql.details.verifyCertificate", true));
-        setMysqlPubKeyRetrievalAllowed((boolean) getDefaultValue("mysql.details.allowPubKeyRetrieval", false));
+        setMySQLPubKeyRetrievalAllowed((boolean) getDefaultValue("mysql.details.allowPubKeyRetrieval", false));
+
+        setServerName((String) getDefaultValue("servername", "default"));
 
         setAllowOtherPluginEditDeathInventory((boolean) getDefaultValue("allow-other-plugins-edit-death-inventory", false));
         setRestoreToPlayerButton((boolean) getDefaultValue("restore-to-player-button", true));
@@ -201,9 +204,11 @@ public class ConfigData {
         mysqlVerifyCertificate = value;
     }
 
-    public static void setMysqlPubKeyRetrievalAllowed(boolean value) {
+    public static void setMySQLPubKeyRetrievalAllowed(boolean value) {
         mysqlPubKeyRetrieval = value;
     }
+
+    public static void setServerName(String value) { serverName = value; }
 
     public static void setRestoreToPlayerButton(boolean value) {
         restoreToPlayerButton = value;
@@ -332,6 +337,8 @@ public class ConfigData {
     public static boolean isMySQLPubKeyRetrievalAllowed() {
         return mysqlPubKeyRetrieval;
     }
+
+    public static String getServerName() { return serverName; }
 
     public static boolean isRestoreToPlayerButton() {
         return restoreToPlayerButton;

--- a/src/main/java/me/danjono/inventoryrollback/config/MessageData.java
+++ b/src/main/java/me/danjono/inventoryrollback/config/MessageData.java
@@ -108,6 +108,7 @@ public class MessageData {
     private static String experienceButtonLore;
 
     // Death logs messages
+    private static String deathLocationServer;
     private static String deathLocationWorld;
     private static String deathLocationX;
     private static String deathLocationY;
@@ -178,6 +179,7 @@ public class MessageData {
         setExperienceButtonLore(convertColorCodes((String) getDefaultValue("attribute-restore.experience.button-lore", "&rLevel %XP%")));
 
         // Death only gui
+        setDeathLocationServer(convertColorCodes((String) getDefaultValue("death-location.server", "&6Server: &f%SERVER%")));
         setDeathLocationWorld(convertColorCodes((String) getDefaultValue("death-location.world", "&6World: &f%WORLD%")));
         setDeathLocationX(convertColorCodes((String) getDefaultValue("death-location.x", "&6X: &f%X%")));
         setDeathLocationY(convertColorCodes((String) getDefaultValue("death-location.y", "&6Y: &f%Y%")));
@@ -345,6 +347,9 @@ public class MessageData {
         experienceButtonLore = message;
     }
 
+    public static void setDeathLocationServer(String message) {
+        deathLocationServer = message;
+    }
     public static void setDeathLocationWorld(String message) {
         deathLocationWorld = message;
     }
@@ -549,6 +554,9 @@ public class MessageData {
         return experienceButtonLore.replaceAll(xpVariable, xp + "");
     }
 
+    public static String getDeathLocationServer(String server) {
+        return deathLocationServer.replace("%SERVER%", server);
+    }
     public static String getDeathLocationWorld(String world) {
         return deathLocationWorld.replace("%WORLD%", world);
     }

--- a/src/main/java/me/danjono/inventoryrollback/data/MySQL.java
+++ b/src/main/java/me/danjono/inventoryrollback/data/MySQL.java
@@ -55,6 +55,7 @@ public class MySQL {
     private double health;
     private int hunger;
     private float saturation;
+    private String server;
     private String world;
     private double x;
     private double y;
@@ -110,7 +111,8 @@ public class MySQL {
                         "`xp` FLOAT NOT NULL," + 
                         "`health` DOUBLE NOT NULL," + 
                         "`hunger` INT NOT NULL," + 
-                        "`saturation` FLOAT NOT NULL," + 
+                        "`saturation` FLOAT NOT NULL," +
+                        "`location_server` TEXT CHARACTER SET utf8 COLLATE utf8_general_ci," +
                         "`location_world` TEXT CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL," + 
                         "`location_x` DOUBLE NOT NULL," + 
                         "`location_y` DOUBLE NOT NULL," + 
@@ -260,6 +262,8 @@ public class MySQL {
         this.saturation = saturation;
     }
 
+    public void setServer(String server) { this.server = server; }
+
     public void setWorld(String world) {
         this.world = world;
     }
@@ -288,7 +292,7 @@ public class MySQL {
         openConnection();
 
         try {
-            String query = "SELECT timestamp,death_reason,location_world,location_x,location_y,location_z " + 
+            String query = "SELECT timestamp,death_reason,location_server,location_world,location_x,location_y,location_z " +
                     "FROM " + backupTable.getTableName() + " WHERE " +
                     "uuid = ? AND timestamp = ?";
             
@@ -298,7 +302,8 @@ public class MySQL {
                 
                 try (ResultSet results = statement.executeQuery()) {
                     results.next();
-                    
+
+                    server = results.getString("location_server");
                     world = results.getString("location_world");
                     x = results.getDouble("location_x");
                     y = results.getDouble("location_y");
@@ -333,6 +338,7 @@ public class MySQL {
                     health = results.getDouble("health");
                     hunger = results.getInt("hunger");
                     saturation = results.getFloat("saturation");
+                    server = results.getString("location_server");
                     world = results.getString("location_world");
                     x = results.getDouble("location_x");
                     y = results.getDouble("location_y");
@@ -375,6 +381,8 @@ public class MySQL {
         return this.saturation;
     }
 
+    public String getServer() { return this.server; }
+
     public String getWorld() {
         return this.world;
     }
@@ -404,8 +412,8 @@ public class MySQL {
 
         try {
             String update = "INSERT INTO " + backupTable.getTableName() + " " +
-                    "(uuid, timestamp, xp, health, hunger, saturation, location_world, location_x, location_y, location_z, version, death_reason, main_inventory, armour, ender_chest)" + " " +
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+                    "(uuid, timestamp, xp, health, hunger, saturation, location_server, location_world, location_x, location_y, location_z, version, death_reason, main_inventory, armour, ender_chest)" + " " +
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
             
             try (PreparedStatement statement = connection.prepareStatement(update)) {
                 statement.setString(1, uuid + "");
@@ -414,15 +422,16 @@ public class MySQL {
                 statement.setDouble(4, health);
                 statement.setInt(5, hunger);
                 statement.setFloat(6, saturation);
-                statement.setString(7, world);
-                statement.setDouble(8, x);
-                statement.setDouble(9, y);
-                statement.setDouble(10, z);
-                statement.setString(11, packageVersion);
-                statement.setString(12, deathReason);
-                statement.setString(13, mainInventory);
-                statement.setString(14, armour);
-                statement.setString(15, enderChest);
+                statement.setString(7, server);
+                statement.setString(8, world);
+                statement.setDouble(9, x);
+                statement.setDouble(10, y);
+                statement.setDouble(11, z);
+                statement.setString(12, packageVersion);
+                statement.setString(13, deathReason);
+                statement.setString(14, mainInventory);
+                statement.setString(15, armour);
+                statement.setString(16, enderChest);
                 statement.executeUpdate();
             }
         } finally {
@@ -482,6 +491,7 @@ public class MySQL {
                     mysql.setHealth(yaml.getHealth());
                     mysql.setFoodLevel(yaml.getFoodLevel());
                     mysql.setSaturation(yaml.getSaturation());
+                    mysql.setServer(yaml.getServer());
                     mysql.setWorld(yaml.getWorld());
                     mysql.setX(yaml.getX());
                     mysql.setY(yaml.getY());

--- a/src/main/java/me/danjono/inventoryrollback/data/PlayerData.java
+++ b/src/main/java/me/danjono/inventoryrollback/data/PlayerData.java
@@ -196,6 +196,14 @@ public class PlayerData {
         }
     }
 
+    public void setServer(String server) {
+        if (ConfigData.getSaveType() == SaveType.YAML) {
+            yaml.setServer(server);
+        } else if (ConfigData.getSaveType() == SaveType.MYSQL) {
+            mysql.setServer(server);
+        }
+    }
+
     public void setWorld(String world) {
         if (ConfigData.getSaveType() == SaveType.YAML) {
             yaml.setWorld(world);
@@ -352,6 +360,15 @@ public class PlayerData {
         }
 
         return 0;
+    }
+    public String getServer() {
+        if (ConfigData.getSaveType() == SaveType.YAML) {
+            return yaml.getServer();
+        } else if (ConfigData.getSaveType() == SaveType.MYSQL) {
+            return mysql.getServer();
+        }
+
+        return null;
     }
 
     public String getWorld() {

--- a/src/main/java/me/danjono/inventoryrollback/data/YAML.java
+++ b/src/main/java/me/danjono/inventoryrollback/data/YAML.java
@@ -35,6 +35,7 @@ public class YAML {
     private double health;
     private int hunger;
     private float saturation;
+    private String server;
     private String world;
     private double x;
     private double y;
@@ -244,6 +245,7 @@ public class YAML {
         this.saturation = saturation;
     }
 
+    public void setServer(String server) { this.server = server; }
     public void setWorld(String world) {
         this.world = world;
     }
@@ -303,6 +305,7 @@ public class YAML {
         return Float.parseFloat(data.getString("saturation"));
     }
 
+    public String getServer() { return data.getString("location.server"); }
     public String getWorld() {
         return data.getString("location.world");
     }
@@ -347,6 +350,7 @@ public class YAML {
         data.set("health", health);
         data.set("hunger", hunger);
         data.set("saturation", saturation);
+        data.set("location.server", server);
         data.set("location.world", world);
         data.set("location.x", x);
         data.set("location.y", y);

--- a/src/main/java/me/danjono/inventoryrollback/gui/Buttons.java
+++ b/src/main/java/me/danjono/inventoryrollback/gui/Buttons.java
@@ -507,10 +507,11 @@ public class Buttons {
         List<String> lore = new ArrayList<>();
         if (location != null) {
             String[] loc = location.split(",");
-            lore.add(ChatColor.GOLD + "World: " + ChatColor.WHITE + loc[0]);
-            lore.add(ChatColor.GOLD + "X: " + ChatColor.WHITE + loc[1]);
-            lore.add(ChatColor.GOLD + "Y: " + ChatColor.WHITE + loc[2]);
-            lore.add(ChatColor.GOLD + "Z: " + ChatColor.WHITE + loc[3]);
+            lore.add(ChatColor.GOLD + "Server: "+ ChatColor.WHITE + loc[0]);
+            lore.add(ChatColor.GOLD + "World: " + ChatColor.WHITE + loc[1]);
+            lore.add(ChatColor.GOLD + "X: " + ChatColor.WHITE + loc[2]);
+            lore.add(ChatColor.GOLD + "Y: " + ChatColor.WHITE + loc[3]);
+            lore.add(ChatColor.GOLD + "Z: " + ChatColor.WHITE + loc[4]);
 
             meta.setLore(lore);
         } else {

--- a/src/main/java/me/danjono/inventoryrollback/gui/menu/MainInventoryBackupMenu.java
+++ b/src/main/java/me/danjono/inventoryrollback/gui/menu/MainInventoryBackupMenu.java
@@ -87,7 +87,11 @@ public class MainInventoryBackupMenu {
 
 				int invPosition = 0;
 				int itemPos = 0;
-				final int max = mainInvLen - 5; // excluded
+
+				// Calculate max based on whether armor is stored separately or not
+				// Old versions (<=1.8): armor stored separately in 'armour' array, process all main inventory
+				// New versions (>=1.9): armor in mainInventory from slot 36+, only process slots 0-35
+				final int max = (armour != null && armour.length > 0) ? mainInvLen : Math.min(36, mainInvLen);
 
 				@Override
 				public void run() {

--- a/src/main/java/me/danjono/inventoryrollback/gui/menu/RollbackListMenu.java
+++ b/src/main/java/me/danjono/inventoryrollback/gui/menu/RollbackListMenu.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import com.nuclyon.technicallycoded.inventoryrollback.InventoryRollbackPlus;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -99,12 +100,16 @@ public class RollbackListMenu {
                 if (deathReason != null)
                     lore.add(MessageData.getDeathReason(deathReason));
 
+                String server = playerData.getServer();
                 String world = playerData.getWorld();
                 double x = playerData.getX();
                 double y = playerData.getY();
                 double z = playerData.getZ();
-                String location = world + "," + x + "," + y + "," + z;
+                String location = server + "," + world + "," + x + "," + y + "," + z;
 
+                InventoryRollbackPlus.getInstance().getLogger().info(location);
+
+                lore.add(MessageData.getDeathLocationServer(server));
                 lore.add(MessageData.getDeathLocationWorld(world));
                 lore.add(MessageData.getDeathLocationX(x));
                 lore.add(MessageData.getDeathLocationY(y));

--- a/src/main/java/me/danjono/inventoryrollback/inventory/SaveInventory.java
+++ b/src/main/java/me/danjono/inventoryrollback/inventory/SaveInventory.java
@@ -5,6 +5,7 @@ import com.nuclyon.technicallycoded.inventoryrollback.util.UserLogRateLimiter;
 import com.nuclyon.technicallycoded.inventoryrollback.util.serialization.ItemStackSerialization;
 import com.tcoded.lightlibs.bukkitversion.BukkitVersion;
 import me.danjono.inventoryrollback.InventoryRollback;
+import me.danjono.inventoryrollback.config.ConfigData;
 import me.danjono.inventoryrollback.data.LogType;
 import me.danjono.inventoryrollback.data.PlayerData;
 import org.bukkit.Location;
@@ -77,6 +78,9 @@ public class SaveInventory {
             data.setHealth(snapshot.health);
             data.setFoodLevel(snapshot.foodLevel);
             data.setSaturation(snapshot.saturation);
+
+            data.setServer(ConfigData.getServerName());
+
             data.setWorld(snapshot.worldName);
 
             data.setX(snapshot.locX);
@@ -137,6 +141,8 @@ public class SaveInventory {
         double health = player.getHealth();
         int foodLevel = player.getFoodLevel();
         float saturation = player.getSaturation();
+
+        String serverName = ConfigData.getServerName();
         String worldName = player.getWorld().getName();
 
         // Location data
@@ -152,7 +158,7 @@ public class SaveInventory {
         ItemStack[] finalMainInvArmor = mainInvArmor;
         ItemStack[] finalEnderInvContents = enderInvContents;
 
-        return new PlayerDataSnapshot(totalXp, health, foodLevel, saturation, worldName, locX, locY, locZ,
+        return new PlayerDataSnapshot(totalXp, health, foodLevel, saturation, serverName, worldName, locX, locY, locZ,
                 finalMainInvContents, finalMainInvArmor, finalEnderInvContents);
     }
 
@@ -171,6 +177,7 @@ public class SaveInventory {
         public final double health;
         public final int foodLevel;
         public final float saturation;
+        public final String serverName;
         public final String worldName;
         public final double locX;
         public final double locY;
@@ -179,11 +186,12 @@ public class SaveInventory {
         public final ItemStack[] finalMainInvArmor;
         public final ItemStack[] finalEnderInvContents;
 
-        public PlayerDataSnapshot(float totalXp, double health, int foodLevel, float saturation, String worldName, double locX, double locY, double locZ, ItemStack[] finalMainInvContents, ItemStack[] finalMainInvArmor, ItemStack[] finalEnderInvContents) {
+        public PlayerDataSnapshot(float totalXp, double health, int foodLevel, float saturation, String serverName, String worldName, double locX, double locY, double locZ, ItemStack[] finalMainInvContents, ItemStack[] finalMainInvArmor, ItemStack[] finalEnderInvContents) {
             this.totalXp = totalXp;
             this.health = health;
             this.foodLevel = foodLevel;
             this.saturation = saturation;
+            this.serverName = serverName;
             this.worldName = worldName;
             this.locX = locX;
             this.locY = locY;
@@ -207,6 +215,7 @@ public class SaveInventory {
             if (Double.compare(that.locY, locY) != 0) return false;
             if (Double.compare(that.locZ, locZ) != 0) return false;
             if (Float.compare(that.totalXp, totalXp) != 0) return false;
+            if (!serverName.equals(that.serverName)) return false;
             if (!worldName.equals(that.worldName)) return false;
             if (!Arrays.equals(finalMainInvContents, that.finalMainInvContents)) return false;
             if (!Arrays.equals(finalMainInvArmor, that.finalMainInvArmor)) return false;
@@ -222,6 +231,7 @@ public class SaveInventory {
                     ", health=" + health +
                     ", foodLevel=" + foodLevel +
                     ", saturation=" + saturation +
+                    ", serverName='" + serverName + "\'" +
                     ", worldName='" + worldName + '\'' +
                     ", locX=" + locX +
                     ", locY=" + locY +

--- a/src/main/java/me/danjono/inventoryrollback/listeners/ClickGUI.java
+++ b/src/main/java/me/danjono/inventoryrollback/listeners/ClickGUI.java
@@ -377,7 +377,7 @@ public class ClickGUI implements Listener {
 
                 if (world == null) {
                     //World is not available
-                    staff.sendMessage(MessageData.getPluginPrefix() + MessageData.getDeathLocationInvalidWorldError(location[0]));
+                    staff.sendMessage(MessageData.getPluginPrefix() + MessageData.getDeathLocationInvalidWorldError(location[1]));
                     return;
                 }
 

--- a/src/main/java/me/danjono/inventoryrollback/listeners/ClickGUI.java
+++ b/src/main/java/me/danjono/inventoryrollback/listeners/ClickGUI.java
@@ -24,6 +24,10 @@ import org.bukkit.inventory.InventoryView;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -71,7 +75,7 @@ public class ClickGUI implements Listener {
 
 
     @EventHandler
-    public void onInventoryClick(InventoryClickEvent e) {
+    public void onInventoryClick(InventoryClickEvent e) throws IOException {
         String title = e.getView().getTitle();
         if (!title.equals(InventoryName.MAIN_MENU.getName()) 
                 && !title.equals(InventoryName.PLAYER_MENU.getName()) 
@@ -260,7 +264,7 @@ public class ClickGUI implements Listener {
         }
     }
 
-    private void mainBackupMenu(InventoryClickEvent e, Player staff, ItemStack icon) {
+    private void mainBackupMenu(InventoryClickEvent e, Player staff, ItemStack icon) throws IOException {
         if (!e.getView().getTitle().equals(InventoryName.MAIN_BACKUP.getName()))
             return;
 
@@ -346,6 +350,8 @@ public class ClickGUI implements Listener {
                 }
             }
 
+            // TODO !!!
+
             // Clicked icon to teleport player to backup coordinates
             else if (icon.getType().equals(Buttons.getTeleportLocationIcon())) {
                 // Perm check
@@ -355,7 +361,19 @@ public class ClickGUI implements Listener {
                 }
 
                 String[] location = nbt.getString("location").split(",");			
-                World world = Bukkit.getWorld(location[0]);
+
+                if (!Objects.equals(ConfigData.getServerName(), location[0])) {
+                    ByteArrayOutputStream b = new ByteArrayOutputStream();
+                    DataOutputStream out = new DataOutputStream(b);
+
+                    out.writeUTF("Connect");
+                    out.writeUTF(location[0]);
+
+                    staff.sendPluginMessage(InventoryRollback.getInstance(), "BungeeCord", b.toByteArray());
+                    return;
+                }
+
+                World world = Bukkit.getWorld(location[1]);
 
                 if (world == null) {
                     //World is not available
@@ -364,9 +382,9 @@ public class ClickGUI implements Listener {
                 }
 
                 Location loc = new Location(world, 
-                        Math.floor(Double.parseDouble(location[1])), 
-                        Math.floor(Double.parseDouble(location[2])), 
-                        Math.floor(Double.parseDouble(location[3])))
+                        Math.floor(Double.parseDouble(location[2])),
+                        Math.floor(Double.parseDouble(location[3])),
+                        Math.floor(Double.parseDouble(location[4])))
                         .add(0.5, 0.5, 0.5);				
 
                 // Teleport player on a slight delay to block the teleport icon glitching out into the player inventory

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -30,6 +30,8 @@ mysql:
     verifyCertificate: true
     allowPubKeyRetrieval: false
 
+servername: default
+
 ## Sounds will play to the player when parts of their player is restored.
 sounds:
   teleport:


### PR DESCRIPTION
Hi,
I had a very specific usecase for this plugin;
We are running multiple servers connected to the same Velocity network, and everything is shared between those servers. Inventory, health, items, and a single Skyblock instance is hosting islands across those servers to reduce and spread load.

We wanted to use Irp on all servers, connected to the same database (so it all feels like the same server). However, all worlds have simular names, so you couldn't tell apart which server a death happened in, so if you tried to visit it the location would not be the same.

With this commit I added part of support to additionally log a servername (configurable in the config). Servernames are shown with the irp's, so you can visually see where it happened. If you try to teleport to one in another server, you will be sent to that server instead. I couldn't figure out a way to TP to the death after you switched servers without the need of some sort of redis / proxy plugin setup, so I figured this was good enough for me.

Feel free to use this, however its not migrating any existing backups yet. We could start with a clean database, so I didn't specifically needed that, and figured if you are not gonne add this (which is understandable) it would be a waste of time.
Everything should work as it is now if you are not using a proxy. It'll just always send to the right location.

This also is a solution to Issue #51 