### PR TITLE
feat: backup navigation

### DIFF
--- a/src/main/java/me/danjono/inventoryrollback/config/MessageData.java
+++ b/src/main/java/me/danjono/inventoryrollback/config/MessageData.java
@@ -120,6 +120,7 @@ public class MessageData {
     private static String deathLocationInvalidWorld;
 
     // Generic gui messages
+    private static String menuTimestamp;
     private static String mainMenuButton;
     private static String nextPageButton;
     private static String previousPageButton;
@@ -191,6 +192,7 @@ public class MessageData {
         setDeathLocationInvalidWorldError(convertColorCodes((String) getDefaultValue("death-location.invalid-world", "The world %WORLD% is not currently loaded on the server.")));
 
         // Generic gui buttons
+        setMenuTimestamp(convertColorCodes((String) getDefaultValue("menu-buttons.timestamp", "&7Timestamp: &f%TIME%")));
         setMainMenuButton(convertColorCodes((String) getDefaultValue("menu-buttons.main-menu", "&fMain Menu")));
         setNextPageButton(convertColorCodes((String) getDefaultValue("menu-buttons.next-page", "&fNext Page")));
         setPreviousPageButton(convertColorCodes((String) getDefaultValue("menu-buttons.previous-page", "&fPrevious Page")));
@@ -386,6 +388,10 @@ public class MessageData {
 
     public static void setDeathLocationInvalidWorldError(String message) {
         deathLocationInvalidWorld = message;
+    }
+
+    public static void setMenuTimestamp(String message) {
+        menuTimestamp = message;
     }
 
     public static void setMainMenuButton(String message) {
@@ -593,6 +599,10 @@ public class MessageData {
 
     public static String getDeathLocationInvalidWorldError(String world) {
         return deathLocationInvalidWorld.replace("%WORLD%", world);
+    }
+
+    public static String getMenuTimestamp(String time) {
+        return menuTimestamp.replace("%TIME%", time);
     }
 
     public static String getMainMenuButton() {

--- a/src/main/java/me/danjono/inventoryrollback/data/MySQL.java
+++ b/src/main/java/me/danjono/inventoryrollback/data/MySQL.java
@@ -217,6 +217,30 @@ public class MySQL {
         }
     }
 
+    public List<Long> getAllTimestamps() throws SQLException {
+        openConnection();
+        
+        List<Long> timeStamps = new ArrayList<>();
+                
+        try {
+            String query = "SELECT timestamp FROM " + backupTable.getTableName() + " WHERE uuid = ? ORDER BY timestamp DESC";
+            
+            try (PreparedStatement statement = connection.prepareStatement(query)) {
+                statement.setString(1, uuid + "");
+                
+                try (ResultSet results = statement.executeQuery()) {
+                    while (results.next()) {
+                        timeStamps.add(results.getLong(1));
+                    }
+                }
+            }
+
+            return timeStamps;
+        } finally {
+            closeConnection();
+        }
+    }
+
     public void purgeExcessSaves(int deleteAmount) throws SQLException {
         openConnection();
 

--- a/src/main/java/me/danjono/inventoryrollback/data/PlayerData.java
+++ b/src/main/java/me/danjono/inventoryrollback/data/PlayerData.java
@@ -108,6 +108,24 @@ public class PlayerData {
         return timeStamps;
     }
 
+    public CompletableFuture<List<Long>> getAllTimestamps() {
+        return CompletableFuture.supplyAsync(() -> {
+            List<Long> timeStamps = new ArrayList<>();
+
+            if (ConfigData.getSaveType() == SaveType.YAML) {
+                timeStamps = yaml.getAllTimestamps();
+            } else if (ConfigData.getSaveType() == SaveType.MYSQL) {
+                try {
+                    timeStamps = mysql.getAllTimestamps();
+                } catch (SQLException e) {
+                    e.printStackTrace();
+                }
+            }
+
+            return timeStamps;
+        });
+    }
+
     public CompletableFuture<Void> purgeExcessSaves(boolean shouldSaveAsync) {
 
         CompletableFuture<Void> future = new CompletableFuture<>();

--- a/src/main/java/me/danjono/inventoryrollback/data/YAML.java
+++ b/src/main/java/me/danjono/inventoryrollback/data/YAML.java
@@ -125,7 +125,7 @@ public class YAML {
         return filesArr.length;
     }
 
-    public List<Long> getSelectedPageTimestamps(int pageNumber) {
+    public List<Long> getAllTimestamps() {
         List<Long> allTimeStamps = new ArrayList<>();
 
         if (!playerBackupFolder.exists())
@@ -150,6 +150,12 @@ public class YAML {
 
         //Set timestamps in order
         Collections.sort(allTimeStamps, Collections.reverseOrder());
+
+        return allTimeStamps;
+    }
+
+    public List<Long> getSelectedPageTimestamps(int pageNumber) {
+        List<Long> allTimeStamps = getAllTimestamps();
 
         //Number of backups that will be on the page
         int backups = InventoryName.ROLLBACK_LIST.getSize() - 9;

--- a/src/main/java/me/danjono/inventoryrollback/gui/Buttons.java
+++ b/src/main/java/me/danjono/inventoryrollback/gui/Buttons.java
@@ -776,7 +776,7 @@ public class Buttons {
         for (int i = 1; i < nameParts.length; i ++) {
             loreParts.add(nameParts[i]);
         }
-        loreParts.add("§7Timestamp: §f" + PlayerData.getTime(timestamp));
+        loreParts.add(MessageData.getMenuTimestamp(PlayerData.getTime(timestamp)));
         meta.setLore(loreParts);
 
         item.setItemMeta(meta);

--- a/src/main/java/me/danjono/inventoryrollback/gui/Buttons.java
+++ b/src/main/java/me/danjono/inventoryrollback/gui/Buttons.java
@@ -5,6 +5,7 @@ import com.nuclyon.technicallycoded.inventoryrollback.customdata.CustomDataItemE
 import com.tcoded.lightlibs.bukkitversion.BukkitVersion;
 import me.danjono.inventoryrollback.config.MessageData;
 import me.danjono.inventoryrollback.data.LogType;
+import me.danjono.inventoryrollback.data.PlayerData;
 import me.danjono.inventoryrollback.inventory.RestoreInventory;
 import org.bukkit.*;
 import org.bukkit.block.banner.Pattern;
@@ -775,6 +776,7 @@ public class Buttons {
         for (int i = 1; i < nameParts.length; i ++) {
             loreParts.add(nameParts[i]);
         }
+        loreParts.add("§7Timestamp: §f" + PlayerData.getTime(timestamp));
         meta.setLore(loreParts);
 
         item.setItemMeta(meta);

--- a/src/main/java/me/danjono/inventoryrollback/gui/Buttons.java
+++ b/src/main/java/me/danjono/inventoryrollback/gui/Buttons.java
@@ -308,6 +308,74 @@ public class Buttons {
         return button;
     }
 
+    public ItemStack inventorySnapshotPreviousButton(String displayName, LogType logType, Long timestamp, List<String> lore) {
+        ItemStack button = new ItemStack(getPageSelectorIcon());
+        BannerMeta meta = (BannerMeta) button.getItemMeta();
+
+        List<Pattern> patterns = createBannerPatterns(false);
+
+        assert meta != null;
+        meta.setPatterns(patterns);
+
+        if (InventoryRollbackPlus.getInstance().getVersion().greaterOrEqThan(BukkitVersion.v1_20_R4)) meta.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+        else meta.addItemFlags(ItemFlag.valueOf("HIDE_POTION_EFFECTS"));
+
+        if (displayName != null) {
+            meta.setDisplayName(displayName);
+        }
+
+        if (lore != null) {
+            meta.setLore(lore);
+        }
+
+        button.setItemMeta(meta);
+
+        CustomDataItemEditor nbt = CustomDataItemEditor.editItem(button);
+
+        nbt.setString("uuid", uuid.toString());
+        nbt.setString("logType", logType.name());
+        nbt.setLong("timestamp", timestamp);
+        nbt.setInt("page", 1);
+
+        button = nbt.setItemData();
+
+        return button;
+    }
+
+    public ItemStack inventorySnapshotNextButton(String displayName, LogType logType, Long timestamp, List<String> lore) {
+        ItemStack button = new ItemStack(getPageSelectorIcon());
+        BannerMeta meta = (BannerMeta) button.getItemMeta();
+
+        List<Pattern> patterns = createBannerPatterns(true);
+
+        assert meta != null;
+        meta.setPatterns(patterns);
+
+        if (InventoryRollbackPlus.getInstance().getVersion().greaterOrEqThan(BukkitVersion.v1_20_R4)) meta.addItemFlags(ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+        else meta.addItemFlags(ItemFlag.valueOf("HIDE_POTION_EFFECTS"));
+
+        if (displayName != null) {
+            meta.setDisplayName(displayName);
+        }
+
+        if (lore != null) {
+            meta.setLore(lore);
+        }
+
+        button.setItemMeta(meta);
+
+        CustomDataItemEditor nbt = CustomDataItemEditor.editItem(button);
+
+        nbt.setString("uuid", uuid.toString());
+        nbt.setString("logType", logType.name());
+        nbt.setLong("timestamp", timestamp);
+        nbt.setInt("page", 2);
+
+        button = nbt.setItemData();
+
+        return button;
+    }
+
     public ItemStack createInventoryButton(ItemStack item, LogType logType, String location, Long time, String displayName, List<String> lore) {    	
         ItemMeta meta = item.getItemMeta();
 

--- a/src/main/java/me/danjono/inventoryrollback/gui/menu/MainInventoryBackupMenu.java
+++ b/src/main/java/me/danjono/inventoryrollback/gui/menu/MainInventoryBackupMenu.java
@@ -76,9 +76,6 @@ public class MainInventoryBackupMenu {
 	
 	public void createInventory() {
 	    inventory = Bukkit.createInventory(staff, InventoryName.MAIN_BACKUP.getSize(), InventoryName.MAIN_BACKUP.getName());
-	    
-	    //Add back button
-        // inventory.setItem(46, buttons.inventoryMenuBackButton(MessageData.getBackButton(), logType, timestamp));
         
         // Add previous backup button if not at first backup
         if (backupPageIndex > 0) {

--- a/src/main/java/me/danjono/inventoryrollback/gui/menu/MainInventoryBackupMenu.java
+++ b/src/main/java/me/danjono/inventoryrollback/gui/menu/MainInventoryBackupMenu.java
@@ -13,6 +13,8 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -39,6 +41,10 @@ public class MainInventoryBackupMenu {
 
 	private int mainInvLen;
 	
+	private int snapshotPageIndex;
+	private List<Long> allSnapshots;
+	private int totalSnapshots;
+	
 	public MainInventoryBackupMenu(Player staff, PlayerData data, String location) {
 		this.main = InventoryRollbackPlus.getInstance();
 
@@ -59,6 +65,8 @@ public class MainInventoryBackupMenu {
 
 		this.mainInvLen = mainInventory == null ? 0 : mainInventory.length;
 		
+		this.snapshotPageIndex = allSnapshots.indexOf(timestamp);
+		
 		createInventory();
 	}
 	
@@ -67,6 +75,22 @@ public class MainInventoryBackupMenu {
 	    
 	    //Add back button
         inventory.setItem(46, buttons.inventoryMenuBackButton(MessageData.getBackButton(), logType, timestamp));
+        
+        // Add previous snapshot button if not at first snapshot
+        if (snapshotPageIndex > 0) {
+        	Long previousTimestamp = allSnapshots.get(snapshotPageIndex - 1);
+        	List<String> lore = new ArrayList<>();
+        	lore.add("Snapshot " + (snapshotPageIndex) + " / " + totalSnapshots);
+        	inventory.setItem(45, buttons.inventorySnapshotPreviousButton(MessageData.getPreviousPageButton(), logType, previousTimestamp, lore));
+        }
+        
+        // Add next snapshot button if not at last snapshot
+        if (snapshotPageIndex < totalSnapshots - 1) {
+        	Long nextTimestamp = allSnapshots.get(snapshotPageIndex + 1);
+        	List<String> lore = new ArrayList<>();
+        	lore.add("Snapshot " + (snapshotPageIndex + 2) + " / " + totalSnapshots);
+        	inventory.setItem(47, buttons.inventorySnapshotNextButton(MessageData.getNextPageButton(), logType, nextTimestamp, lore));
+        }
 	}
 	
 	public Inventory getInventory() {

--- a/src/main/java/me/danjono/inventoryrollback/gui/menu/MainInventoryBackupMenu.java
+++ b/src/main/java/me/danjono/inventoryrollback/gui/menu/MainInventoryBackupMenu.java
@@ -43,11 +43,11 @@ public class MainInventoryBackupMenu {
 
 	private int mainInvLen;
 	
-	private int snapshotPageIndex;
-	private List<Long> allSnapshots;
-	private int totalSnapshots;
+	private int backupPageIndex;
+	private List<Long> allBackups;
+	private int totalBackups;
 	
-	public MainInventoryBackupMenu(Player staff, PlayerData data, String location) {
+	public MainInventoryBackupMenu(Player staff, PlayerData data, String location, List<Long> allBackups) {
 		this.main = InventoryRollbackPlus.getInstance();
 
 		this.staff = staff;
@@ -67,7 +67,9 @@ public class MainInventoryBackupMenu {
 
 		this.mainInvLen = mainInventory == null ? 0 : mainInventory.length;
 		
-		this.snapshotPageIndex = allSnapshots.indexOf(timestamp);
+		this.allBackups = allBackups;
+		this.backupPageIndex = allBackups != null ? allBackups.indexOf(timestamp) : 0;
+		this.totalBackups = allBackups != null ? allBackups.size() : data.getAmountOfBackups();
 		
 		createInventory();
 	}
@@ -76,24 +78,24 @@ public class MainInventoryBackupMenu {
 	    inventory = Bukkit.createInventory(staff, InventoryName.MAIN_BACKUP.getSize(), InventoryName.MAIN_BACKUP.getName());
 	    
 	    //Add back button
-        inventory.setItem(46, buttons.inventoryMenuBackButton(MessageData.getBackButton(), logType, timestamp));
+        // inventory.setItem(46, buttons.inventoryMenuBackButton(MessageData.getBackButton(), logType, timestamp));
         
-        // Add previous snapshot button if not at first snapshot
-        if (snapshotPageIndex > 0) {
-        	Long previousTimestamp = allSnapshots.get(snapshotPageIndex - 1);
+        // Add previous backup button if not at first backup
+        if (backupPageIndex > 0) {
+        	Long previousTimestamp = allBackups.get(backupPageIndex - 1);
         	List<String> lore = new ArrayList<>();
-        	lore.add("Snapshot " + (snapshotPageIndex) + " / " + totalSnapshots);
+        	lore.add("Go to backup " + (backupPageIndex) + " / " + totalBackups);
+        	lore.add("Right-click to return to backup list");
         	inventory.setItem(45, buttons.inventorySnapshotPreviousButton(MessageData.getPreviousPageButton(), logType, previousTimestamp, lore));
         }
         
-        // Add next snapshot button if not at last snapshot
-        if (snapshotPageIndex < totalSnapshots - 1) {
-        	Long nextTimestamp = allSnapshots.get(snapshotPageIndex + 1);
+        // Add next backup button if not at last backup
+        if (backupPageIndex < totalBackups - 1) {
+        	Long nextTimestamp = allBackups.get(backupPageIndex + 1);
         	List<String> lore = new ArrayList<>();
-        	lore.add("Snapshot " + (snapshotPageIndex + 2) + " / " + totalSnapshots);
-        	inventory.setItem(47, buttons.inventorySnapshotNextButton(MessageData.getNextPageButton(), logType, nextTimestamp, lore));
+        	lore.add("Go to backup " + (backupPageIndex + 2) + " / " + totalBackups);
+        	inventory.setItem(46, buttons.inventorySnapshotNextButton(MessageData.getNextPageButton(), logType, nextTimestamp, lore));
         }
-        inventory.setItem(45, buttons.inventoryMenuBackButton(MessageData.getBackButton(), logType, timestamp));
 
 		// Add get shulker button
 		if (main.getVersion().greaterOrEqThan(MCVersion.v1_11.toBukkitVersion()))

--- a/src/main/java/me/danjono/inventoryrollback/listeners/ClickGUI.java
+++ b/src/main/java/me/danjono/inventoryrollback/listeners/ClickGUI.java
@@ -29,6 +29,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -220,8 +221,16 @@ public class ClickGUI implements Listener {
                             }
                         }
 
+                        // Get all timestamps for navigation
+                        List<Long> allBackupTimestamps = null;
+                        try {
+                            allBackupTimestamps = data.getAllTimestamps().get();
+                        } catch (ExecutionException | InterruptedException ex) {
+                            ex.printStackTrace();
+                        }
+
                         // Create inventory
-                        MainInventoryBackupMenu menu = new MainInventoryBackupMenu(staff, data, location);
+                        MainInventoryBackupMenu menu = new MainInventoryBackupMenu(staff, data, location, allBackupTimestamps);
 
                         // Display inventory to player
                         Future<InventoryView> inventoryViewFuture =
@@ -278,15 +287,65 @@ public class ClickGUI implements Listener {
             LogType logType = LogType.valueOf(nbt.getString("logType"));
             Long timestamp = nbt.getLong("timestamp");
 
-            //Click on page selector button to go back to rollback menu
+            // Click on page selector button - handle navigation or go back to rollback menu
             if (icon.getType().equals(Buttons.getPageSelectorIcon())) {
-                RollbackListMenu menu = new RollbackListMenu(staff, offlinePlayer, logType, 1);
+                int page = nbt.getInt("page");
 
-                staff.openInventory(menu.getInventory());
-                Bukkit.getScheduler().runTaskAsynchronously(InventoryRollback.getInstance(), menu::showBackups);
+                if (e.isRightClick() && page == 1) {
+                    page = 0;
+                }
+
+                // page == 1 means previous backup, page == 2 means next backup
+                if (page == 1 || page == 2) {
+                    UUID uuid = offlinePlayer.getUniqueId();
+
+                    new BukkitRunnable() {
+                        @Override
+                        public void run() {
+                            PlayerData data = new PlayerData(uuid, logType, timestamp);
+
+                            if (ConfigData.getSaveType() == ConfigData.SaveType.MYSQL) {
+                                try {
+                                    data.getAllBackupData().get();
+                                } catch (ExecutionException | InterruptedException ex) {
+                                    ex.printStackTrace();
+                                }
+                            }
+
+                            // Get all timestamps for navigation
+                            List<Long> allBackupTimestamps = null;
+                            try {
+                                allBackupTimestamps = data.getAllTimestamps().get();
+                            } catch (ExecutionException | InterruptedException ex) {
+                                ex.printStackTrace();
+                            }
+
+                            String location = data.getWorld() + "," + data.getX() + "," + data.getY() + "," + data.getZ();
+
+                            MainInventoryBackupMenu menu = new MainInventoryBackupMenu(staff, data, location, allBackupTimestamps);
+
+                            Future<InventoryView> inventoryViewFuture =
+                                    main.getServer().getScheduler().callSyncMethod(main,
+                                            () -> staff.openInventory(menu.getInventory()));
+                            try {
+                                inventoryViewFuture.get();
+                                // Start placing items in the inventory async
+                                menu.showBackupItems();
+                            } catch (NullPointerException | ExecutionException | InterruptedException ex) {
+                                ex.printStackTrace();
+                            }
+                        }
+                    }.runTaskAsynchronously(main);
+                } else {
+                    // page == 0 or other - go back to rollback list menu
+                    RollbackListMenu menu = new RollbackListMenu(staff, offlinePlayer, logType, 1);
+
+                    staff.openInventory(menu.getInventory());
+                    Bukkit.getScheduler().runTaskAsynchronously(InventoryRollback.getInstance(), menu::showBackups);
+                }
             }
 
-            //Click on page selector button to go back to rollback menu
+            // Click on page selector button to go back to rollback menu
             else if (e.getRawSlot() == MainInventoryBackupMenu.GIVE_SHULKERS_BUTTON_SLOT) {
                 // Perm check
                 if (!staff.hasPermission("inventoryrollbackplus.restore")) {
@@ -650,8 +709,16 @@ public class ClickGUI implements Listener {
                             // Get location of where the backup was made from data
                             String location = data.getWorld() + "," + data.getX() + "," + data.getY() + "," + data.getZ();
 
+                            // Get all timestamps for navigation
+                            List<Long> allBackupTimestamps = null;
+                            try {
+                                allBackupTimestamps = data.getAllTimestamps().get();
+                            } catch (ExecutionException | InterruptedException ex) {
+                                ex.printStackTrace();
+                            }
+
                             // Create inventory
-                            MainInventoryBackupMenu menu = new MainInventoryBackupMenu(staff, data, location);
+                            MainInventoryBackupMenu menu = new MainInventoryBackupMenu(staff, data, location, allBackupTimestamps);
 
                             // Display inventory to player
                             Future<InventoryView> inventoryViewFuture = main.getServer().getScheduler().callSyncMethod(main,

--- a/src/main/resources/lang/en_us.yml
+++ b/src/main/resources/lang/en_us.yml
@@ -59,6 +59,7 @@ death-location:
   invalid-world: 'The world %WORLD% is not currently loaded on the server.'
 
 menu-buttons:
+  timestamp: '&7Timestamp: &f%TIME%'
   main-menu: '&fMain Menu'
   next-page: '&fNext Page'
   previous-page: '&fPrevious Page'


### PR DESCRIPTION
This PR implements the following:
- Navigation buttons between each backup to allow the user to "scroll" without having to to back to the rollback list menu
- Timestamp shown in the "Shulker box" lore to indicate the current backup
- "Back to rollback list" button has been moved to a right click of the "Previous rollback" button (ran out of space for new buttons)

<img width="537" height="422" alt="image" src="https://github.com/user-attachments/assets/866d0c41-899c-41b1-a728-84d0671ea337" />

<img width="631" height="188" alt="image" src="https://github.com/user-attachments/assets/13b86945-a24f-47c9-8027-2943a0726922" />

<img width="631" height="188" alt="image" src="https://github.com/user-attachments/assets/e19a50d4-b7b5-46dd-a265-18dfbd23831f" />

<img width="816" height="193" alt="image" src="https://github.com/user-attachments/assets/ea7b7d47-2daa-494d-98bb-90b3db2bc327" />

