### PR TITLE
Improve a lot shulker box export and fix ender chest display

### DIFF
--- a/src/main/java/me/danjono/inventoryrollback/config/MessageData.java
+++ b/src/main/java/me/danjono/inventoryrollback/config/MessageData.java
@@ -8,6 +8,8 @@ import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Level;
 
 public class MessageData {
@@ -81,7 +83,6 @@ public class MessageData {
     private static String mainInventoryNotOnline;
     private static String mainInventoryButton;
     private static String mainInventoryDisabledButton;
-    private static String shulkerBoxButton;
 
     // Ender chest GUI messages
     private static String enderChestRestored;
@@ -107,6 +108,17 @@ public class MessageData {
     private static String experienceNotOnline;
     private static String experienceButton;
     private static String experienceButtonLore;
+
+    // Shulkerbox GUI messages
+    private static String shulkerBoxExported;
+    private static String shulkerBoxButton;
+    private static String shulkerBoxFirstShulkerName;
+    private static List<String> shulkerBoxFirstShulkerLore;
+    private static String shulkerBoxSecondShulkerName;
+    private static List<String> shulkerBoxSecondShulkerLore;
+    private static String shulkerBoxEnderChestShulkerName;
+    private static String shulkerBoxEnderChestShulkerExtraShulkers;
+    private static List<String> shulkerBoxEnderChestShulkerLore;
 
     // Death logs messages
     private static String deathLocationWorld;
@@ -152,7 +164,6 @@ public class MessageData {
         setMainInventoryNotOnline(convertColorCodes((String) getDefaultValue("attribute-restore.main-inventory.not-online", "You can't restore %NAME%'s inventory while they are offline.")));
         setMainInventoryButton(convertColorCodes((String) getDefaultValue("attribute-restore.main-inventory.button-name", "&cOverwrite Main Inventory from Backup")));
         setMainInventoryDisabledButton(convertColorCodes((String) getDefaultValue("attribute-restore.main-inventory.button-disabled", "&cYou must enable this option in the configuration")));
-        setShulkerBoxButton(convertColorCodes((String) getDefaultValue("attribute-restore.main-inventory.shulker-box", "&dExport to Shulker Boxes")));
 
         // Ender chest gui
         setEnderChestRestored(convertColorCodes((String) getDefaultValue("attribute-restore.ender-chest.restored", "%NAME%'s ender chest has been restored.")));
@@ -189,6 +200,17 @@ public class MessageData {
         setDeathLocation(convertColorCodes((String) getDefaultValue("death-location.teleport-to", "&3Teleport to where this entry was logged.")));
         setDeathLocationTeleport(convertColorCodes((String) getDefaultValue("death-location.teleport", "You have been teleported to %LOCATION%")));
         setDeathLocationInvalidWorldError(convertColorCodes((String) getDefaultValue("death-location.invalid-world", "The world %WORLD% is not currently loaded on the server.")));
+
+        // Shulkerbox gui
+        setShulkerBoxExported(convertColorCodes((String) getDefaultValue("shulkerbox.exported", "Exported inventory to shulker boxes. Check your inventory!")));
+        setShulkerBoxButton(convertColorCodes((String) getDefaultValue("shulkerbox.button-name", "&dExport to Shulker Boxes")));
+        setShulkerBoxFirstShulkerName(convertColorCodes((String) getDefaultValue("shulkerbox.first-shulker.name", "&dFirst Shulker Box")));
+        setShulkerBoxFirstShulkerLore(convertColorCodes((String) getDefaultValue("shulkerbox.first-shulker.lore", "&7Contains the hotbar, armor & off-hand slots.")));
+        setShulkerBoxSecondShulkerName(convertColorCodes((String) getDefaultValue("shulkerbox.second-shulker.name", "&dSecond Shulker Box")));
+        setShulkerBoxSecondShulkerLore(convertColorCodes((String) getDefaultValue("shulkerbox.second-shulker.lore", "&7Contains the main inventory slots.")));
+        setShulkerBoxEnderChestShulkerName(convertColorCodes((String) getDefaultValue("shulkerbox.ender-chest-shulker.name", "&dEnder Chest Shulker Box")));
+        setShulkerBoxEnderChestShulkerExtraShulkers(convertColorCodes((String) getDefaultValue("shulkerbox.ender-chest-shulker.extra-shulkers", " &7(#%NUMBER%)")));
+        setShulkerBoxEnderChestShulkerLore(convertColorCodes((String) getDefaultValue("shulkerbox.ender-chest-shulker.lore", "&7Contains the ender chest inventory.")));
 
         // Generic gui buttons
         setMainMenuButton(convertColorCodes((String) getDefaultValue("menu-buttons.main-menu", "&fMain Menu")));
@@ -270,17 +292,13 @@ public class MessageData {
     public static void setMainInventoryNotOnline(String message) {
         mainInventoryNotOnline = message;
     }
-    
+
     public static void setMainInventoryButton(String message) {
         mainInventoryButton = message;
     }
 
     public static void setMainInventoryDisabledButton(String message) {
         mainInventoryDisabledButton = message;
-    }
-
-    public static void setShulkerBoxButton(String message) {
-        shulkerBoxButton = message;
     }
 
     public static void setEnderChestRestored(String message) {
@@ -294,7 +312,7 @@ public class MessageData {
     public static void setEnderChestNotOnline(String message) {
         enderChestNotOnline = message;
     }
-    
+
     public static void setEnderChestButton(String message) {
         enderChestButton = message;
     }
@@ -310,7 +328,7 @@ public class MessageData {
     public static void setHealthNotOnline(String message) {
         healthNotOnline = message;
     }
-    
+
     public static void setHealthButton(String message) {
         healthButton = message;
     }
@@ -326,7 +344,7 @@ public class MessageData {
     public static void setHungerNotOnline(String message) {
         hungerNotOnline = message;
     }
-    
+
     public static void setHungerButton(String message) {
         hungerButton = message;
     }
@@ -342,13 +360,61 @@ public class MessageData {
     public static void setExperienceNotOnlinePlayer(String message) {
         experienceNotOnline = message;
     }
-    
+
     public static void setExperienceButton(String message) {
         experienceButton = message;
     }
 
     public static void setExperienceButtonLore(String message) {
         experienceButtonLore = message;
+    }
+
+    public static void setShulkerBoxExported(String message) {
+        shulkerBoxExported = message;
+    }
+
+    public static void setShulkerBoxButton(String message) {
+        shulkerBoxButton = message;
+    }
+
+    public static void setShulkerBoxFirstShulkerName(String message) {
+        shulkerBoxFirstShulkerName = message;
+    }
+
+    public static void setShulkerBoxFirstShulkerLore(List<String> message) {
+        shulkerBoxFirstShulkerLore = message;
+    }
+    public static void setShulkerBoxFirstShulkerLore(String message) {
+        shulkerBoxFirstShulkerLore = new ArrayList<>();
+        shulkerBoxFirstShulkerLore.add(message);
+    }
+
+    public static void setShulkerBoxSecondShulkerName(String message) {
+        shulkerBoxSecondShulkerName = message;
+    }
+
+    public static void setShulkerBoxSecondShulkerLore(List<String> message) {
+        shulkerBoxSecondShulkerLore = message;
+    }
+    public static void setShulkerBoxSecondShulkerLore(String message) {
+        shulkerBoxSecondShulkerLore = new ArrayList<>();
+        shulkerBoxSecondShulkerLore.add(message);
+    }
+
+    public static void setShulkerBoxEnderChestShulkerName(String message) {
+        shulkerBoxEnderChestShulkerName = message;
+    }
+
+    public static void setShulkerBoxEnderChestShulkerExtraShulkers(String message) {
+        shulkerBoxEnderChestShulkerExtraShulkers = message;
+    }
+
+    public static void setShulkerBoxEnderChestShulkerLore(List<String> message) {
+        shulkerBoxEnderChestShulkerLore = message;
+    }
+    public static void setShulkerBoxEnderChestShulkerLore(String message) {
+        shulkerBoxEnderChestShulkerLore = new ArrayList<>();
+        shulkerBoxEnderChestShulkerLore.add(message);
     }
 
     public static void setDeathLocationWorld(String message) {
@@ -366,7 +432,7 @@ public class MessageData {
     public static void setDeathLocationZ(String message) {
         deathLocationZ = message;
     }
-    
+
     public static void setDeathReason(String message) {
         deathReason = message;
     }
@@ -374,7 +440,7 @@ public class MessageData {
     public static void setDeathTime(String message) {
         deathTime = message;
     }
-    
+
     public static void setDeathLocation(String message) {
         deathLocationTeleportTo = message;
     }
@@ -458,7 +524,7 @@ public class MessageData {
     public static String getForceBackupPlayer(String name) {
         return forceSavedPlayer.replaceAll(nameVariable, name);
     }
-    
+
     public static String getForceBackupAll() {
         return forceSavedAll;
     }
@@ -466,7 +532,7 @@ public class MessageData {
     public static String getForceBackupError(String name) {
         return notForcedSaved.replaceAll(nameVariable, name);
     }
-    
+
     public static String getMainInventoryRestored(String name) {
         return mainInventoryRestored.replaceAll(nameVariable, name);
     }
@@ -478,17 +544,13 @@ public class MessageData {
     public static String getMainInventoryNotOnline(String name) {
         return mainInventoryNotOnline.replaceAll(nameVariable, name);
     }
-    
+
     public static String getMainInventoryRestoreButton() {
         return mainInventoryButton;
     }
 
     public static String getMainInventoryDisabledButton() {
         return mainInventoryDisabledButton;
-    }
-
-    public static String getShulkerBoxButton() {
-        return shulkerBoxButton;
     }
 
     public static String getEnderChestRestored(String name) {
@@ -502,7 +564,7 @@ public class MessageData {
     public static String getEnderChestNotOnline(String name) {
         return enderChestNotOnline.replaceAll(nameVariable, name);
     }
-    
+
     public static String getEnderChestRestoreButton() {
         return enderChestButton;
     }
@@ -518,7 +580,7 @@ public class MessageData {
     public static String getHealthNotOnline(String name) {
         return healthNotOnline.replaceAll(nameVariable, name);
     }
-    
+
     public static String getHealthRestoreButton() {
         return healthButton;
     }
@@ -534,7 +596,7 @@ public class MessageData {
     public static String getHungerNotOnline(String name) {
         return hungerNotOnline.replaceAll(nameVariable, name);
     }
-    
+
     public static String getHungerRestoreButton() {
         return hungerButton;
     }
@@ -550,13 +612,49 @@ public class MessageData {
     public static String getExperienceNotOnlinePlayer(String name) {
         return experienceNotOnline.replaceAll(nameVariable, name);
     }
-    
+
     public static String getExperienceRestoreButton() {
         return experienceButton;
     }
-    
+
     public static String getExperienceRestoreLevel(int xp) {
         return experienceButtonLore.replaceAll(xpVariable, xp + "");
+    }
+
+    public static String getShulkerBoxExported() {
+        return shulkerBoxExported;
+    }
+
+    public static String getShulkerBoxButton() {
+        return shulkerBoxButton;
+    }
+
+    public static String getShulkerBoxFirstShulkerName() {
+        return shulkerBoxFirstShulkerName;
+    }
+
+    public static List<String> getShulkerBoxFirstShulkerLore() {
+        return shulkerBoxFirstShulkerLore;
+    }
+
+    public static String getShulkerBoxSecondShulkerName() {
+        return shulkerBoxSecondShulkerName;
+    }
+
+    public static List<String> getShulkerBoxSecondShulkerLore() {
+        return shulkerBoxSecondShulkerLore;
+    }
+
+    public static String getShulkerBoxEnderChestShulkerName() {
+        return shulkerBoxEnderChestShulkerName;
+    }
+
+    public static String getShulkerBoxEnderChestShulkerExtraShulkers(int number) {
+        return shulkerBoxEnderChestShulkerExtraShulkers.replace("%NUMBER%", String.valueOf(number));
+    }
+
+    public static List<String> getShulkerBoxEnderChestShulkerLore() {
+        return shulkerBoxEnderChestShulkerLore;
     }
 
     public static String getDeathLocationWorld(String world) {

--- a/src/main/java/me/danjono/inventoryrollback/gui/menu/EnderChestBackupMenu.java
+++ b/src/main/java/me/danjono/inventoryrollback/gui/menu/EnderChestBackupMenu.java
@@ -1,6 +1,7 @@
 package me.danjono.inventoryrollback.gui.menu;
 
 import com.nuclyon.technicallycoded.inventoryrollback.InventoryRollbackPlus;
+import com.tcoded.lightlibs.bukkitversion.MCVersion;
 import me.danjono.inventoryrollback.config.ConfigData;
 import me.danjono.inventoryrollback.config.MessageData;
 import me.danjono.inventoryrollback.data.LogType;
@@ -19,6 +20,8 @@ import java.util.UUID;
 
 public class EnderChestBackupMenu {
 
+    public static final int GIVE_SHULKERS_BUTTON_SLOT = InventoryName.ENDER_CHEST_BACKUP.getSize() - 6;
+    private final InventoryRollbackPlus main;
     private int pageNumber;
 
     private Player staff;
@@ -31,6 +34,8 @@ public class EnderChestBackupMenu {
     private Inventory inventory;
 
     public EnderChestBackupMenu(Player staff, PlayerData data, int pageNumberIn) {
+        this.main = InventoryRollbackPlus.getInstance();
+
         this.staff = staff;
         this.playerUUID = data.getOfflinePlayer().getUniqueId();
         this.logType = data.getLogType();
@@ -102,12 +107,8 @@ public class EnderChestBackupMenu {
 
 
                         ItemStack itemStack = enderchest[itemPos];
-                        if (itemStack != null) {
-                            inventory.setItem(invPosition, itemStack);
-                            // Don't change inv position if there was nothing to place
-                            invPosition++;
-                        }
-                        // Move to next item stack
+                        inventory.setItem(invPosition, itemStack); // setting null is fine (clears/keeps empty)
+                        invPosition++;
                         itemPos++;
                     }
                 }
@@ -128,6 +129,8 @@ public class EnderChestBackupMenu {
                     buttons.restoreAllInventoryDisabled(logType, timestamp));
         }
 
+        if (main.getVersion().greaterOrEqThan(MCVersion.v1_11.toBukkitVersion()))
+            inventory.setItem(GIVE_SHULKERS_BUTTON_SLOT, buttons.giveShulkerBox(logType, timestamp));
 
         List<String> lore = new ArrayList<>();
         if (pageNumber < pagesRequired) {

--- a/src/main/java/me/danjono/inventoryrollback/gui/menu/MainInventoryBackupMenu.java
+++ b/src/main/java/me/danjono/inventoryrollback/gui/menu/MainInventoryBackupMenu.java
@@ -20,7 +20,7 @@ import java.util.concurrent.Future;
 
 public class MainInventoryBackupMenu {
 
-	public static final int GIVE_SHULKERS_BUTTON_SLOT = 47;
+    public static final int GIVE_SHULKERS_BUTTON_SLOT = 47;
 	private final InventoryRollbackPlus main;
 
 	private final Player staff;

--- a/src/main/java/me/danjono/inventoryrollback/listeners/ClickGUI.java
+++ b/src/main/java/me/danjono/inventoryrollback/listeners/ClickGUI.java
@@ -28,7 +28,9 @@ import org.bukkit.inventory.meta.BlockStateMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -346,6 +348,8 @@ public class ClickGUI implements Listener {
                             ShulkerBox shulkerBox = (ShulkerBox) blockMeta.getBlockState();
                             shulkerBox.getInventory().setContents(firstShulkerContents);
                             blockMeta.setBlockState(shulkerBox);
+                            blockMeta.setDisplayName(MessageData.getShulkerBoxFirstShulkerName());
+                            blockMeta.setLore(MessageData.getShulkerBoxFirstShulkerLore());
                             firstShulker.setItemMeta(blockMeta);
                         }
                     }
@@ -357,6 +361,8 @@ public class ClickGUI implements Listener {
                             ShulkerBox shulkerBox = (ShulkerBox) blockMeta.getBlockState();
                             shulkerBox.getInventory().setContents(secondShulkerContents);
                             blockMeta.setBlockState(shulkerBox);
+                            blockMeta.setDisplayName(MessageData.getShulkerBoxSecondShulkerName());
+                            blockMeta.setLore(MessageData.getShulkerBoxSecondShulkerLore());
                             secondShulker.setItemMeta(blockMeta);
                         }
                     }
@@ -704,6 +710,77 @@ public class ClickGUI implements Listener {
                         }
                     }.runTaskAsynchronously(this.main);
                 }
+            }
+
+            //Click on page selector button to go back to rollback menu
+            else if (e.getRawSlot() == EnderChestBackupMenu.GIVE_SHULKERS_BUTTON_SLOT) {
+                // Perm check
+                if (!staff.hasPermission("inventoryrollbackplus.restore")) {
+                    staff.sendMessage(MessageData.getPluginPrefix() + MessageData.getNoPermission());
+                    return;
+                }
+
+                Bukkit.getScheduler().runTaskAsynchronously(InventoryRollback.getInstance(), () -> {
+                    // Unsupported on older versions
+                    if (main.getVersion().lessThan(MCVersion.v1_11.toBukkitVersion())) {
+                        return;
+                    }
+
+                    // Give shulkers
+
+                    // Init from MySQL or, if YAML, init & load config file
+                    PlayerData data = new PlayerData(offlinePlayer, logType, timestamp);
+
+                    // Get data if using MySQL
+                    if (ConfigData.getSaveType() == ConfigData.SaveType.MYSQL) {
+                        try {
+                            data.getAllBackupData().get();
+                        } catch (ExecutionException | InterruptedException ex) {
+                            ex.printStackTrace();
+                        }
+                    }
+
+                    ItemStack[] enderChest = data.getEnderChest();
+
+                    List<ItemStack> shulkers = new ArrayList<>();
+                    if (enderChest != null && enderChest.length != 0) {
+                        int totalItems = enderChest.length;
+                        int shulkerCount = (int) Math.ceil(totalItems / 27.0);
+
+                        for (int i = 0; i < shulkerCount; i++) {
+                            int start = i * 27;
+                            int end = Math.min(start + 27, totalItems);
+
+                            ItemStack[] shulkerContents = new ItemStack[27];
+                            System.arraycopy(enderChest, start, shulkerContents, 0, end - start);
+
+                            ItemStack shulker = new ItemStack(Material.SHULKER_BOX);
+                            ItemMeta meta = shulker.getItemMeta();
+
+                            if (meta instanceof BlockStateMeta) {
+                                BlockStateMeta blockMeta = (BlockStateMeta) meta;
+                                if (blockMeta.getBlockState() instanceof ShulkerBox) {
+                                    ShulkerBox shulkerBox = (ShulkerBox) blockMeta.getBlockState();
+                                    shulkerBox.getInventory().setContents(shulkerContents);
+                                    blockMeta.setBlockState(shulkerBox);
+                                    String name = (shulkerCount == 1)
+                                            ? MessageData.getShulkerBoxEnderChestShulkerName()
+                                            : (MessageData.getShulkerBoxEnderChestShulkerName() + MessageData.getShulkerBoxEnderChestShulkerExtraShulkers(i+1));
+                                    blockMeta.setDisplayName(name);
+                                    blockMeta.setLore(MessageData.getShulkerBoxEnderChestShulkerLore());
+                                    shulker.setItemMeta(blockMeta);
+                                }
+                            }
+
+                            shulkers.add(shulker);
+                        }
+                    };
+
+                    Bukkit.getScheduler().runTask(main, t -> {
+                        staff.getInventory().addItem(shulkers.toArray(new ItemStack[0]));
+                        staff.closeInventory();
+                    });
+                });
             }
 
             //Clicked icon to overwrite player ender chest with backup data

--- a/src/main/resources/lang/en_us.yml
+++ b/src/main/resources/lang/en_us.yml
@@ -47,6 +47,20 @@ attribute-restore:
     button-name: '&2Restore Player XP'
     button-lore: '&rLevel %XP%'
 
+shulkerbox:
+  exported: "Exported inventory to shulker boxes. Check your inventory!"
+  button-name: "&dExport to Shulker Boxes"
+  first-shulker:
+    name: "&dFirst Shulker Box"
+    lore: "&7Contains the hotbar, armor & off-hand slots."
+  second-shulker:
+    name: "&dSecond Shulker Box"
+    lore: "&7Contains the main inventory slots."
+  ender-chest-shulker:
+    name: "&dEnder Chest Shulker Box"
+    extra-shulkers: " &7(#%NUMBER%)"
+    lore: "&7Contains the ender chest inventory."
+
 death-location:
   world: '&6World: &f%WORLD%'
   x: '&6X: &f%X%'

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -46,6 +46,20 @@ attribute-restore:
     button-name: '&2Restore Player XP'
     button-lore: '&rLevel %XP%'
 
+shulkerbox:
+  exported: "Exported inventory to shulker boxes. Check your inventory!"
+  button-name: "&dExport to Shulker Boxes"
+  first-shulker:
+    name: "&dFirst Shulker Box"
+    lore: "&7Contains the hotbar, armor & off-hand slots."
+  second-shulker:
+    name: "&dSecond Shulker Box"
+    lore: "&7Contains the main inventory slots."
+  ender-chest-shulker:
+    name: "&dEnder Chest Shulker Box"
+    extra-shulkers: " &7(#%NUMBER%)"
+    lore: "&7Contains the ender chest inventory."
+
 death-location:  
   world: '&6World: &f%WORLD%'
   x: '&6X: &f%X%'


### PR DESCRIPTION
This PR improves the existing shulker box export feature by adding proper names and lore, plus an option to export ender chest contents.
It also fixes the ender chest display being shown in the wrong slot and updates the GUI, config, and messages accordingly.

Tested on:
- Paper 1.21.11
- Purpur 1.21.11 (For 6 rows ender chest)
Note: Since it's almost the same code from the already existing export logic it should work fine in all the versions the plugin support.

Ender Chest display bug: The plugin was skipping inventory positions for empty ender chest slots, this PR makes the GUI always fill slots correctly, even when they’re empty.
Images below show the before & after.
Before:
<img width="412" height="218" alt="image" src="https://github.com/user-attachments/assets/52ab3830-9786-4ca0-adc5-cf9364a14d50" />
After:
<img width="370" height="207" alt="image" src="https://github.com/user-attachments/assets/12ce2561-c64a-42da-b3bb-f0522ed0bbb3" />
