### PR TITLE
Fix NPE

### DIFF
--- a/src/main/java/me/danjono/inventoryrollback/inventory/SaveInventory.java
+++ b/src/main/java/me/danjono/inventoryrollback/inventory/SaveInventory.java
@@ -14,10 +14,11 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -44,13 +45,13 @@ public class SaveInventory {
 
     public void snapshotAndSave(PlayerInventory mainInventory, Inventory enderChestInventory, boolean saveAsync) {
         PlayerDataSnapshot snapshot = createSnapshot(mainInventory, enderChestInventory);
-        if (snapshot == null) return;
+        if (snapshot.isEmptySnapshot()) return;
         
         save(snapshot, saveAsync);
     }
 
     public void save(PlayerDataSnapshot snapshot, boolean async) {
-        if (snapshot == null) return;
+        if (snapshot.isEmptySnapshot()) return;
         UUID uuid = player.getUniqueId();
 
         // Rate limiter
@@ -103,7 +104,7 @@ public class SaveInventory {
 
     }
 
-    public @Nullable PlayerDataSnapshot createSnapshot(PlayerInventory mainInventory, Inventory enderChestInventory) {
+    public @NotNull PlayerDataSnapshot createSnapshot(PlayerInventory mainInventory, Inventory enderChestInventory) {
         ItemStack[] mainInvContents = null;
         ItemStack[] mainInvArmor = null;
         ItemStack[] enderInvContents = null;
@@ -125,7 +126,7 @@ public class SaveInventory {
 
         // Skip saving when inv is empty and config allows skipping empty invs
         if (emptyInvAndArmor && !ConfigData.isSaveEmptyInventories()) {
-            return null;
+            return PlayerDataSnapshot.EMPTY_SNAPSHOT;
         }
 
         ItemStack[] enderContents = enderChestInventory.getContents();
@@ -203,6 +204,24 @@ public class SaveInventory {
             this.finalEnderInvContents = finalEnderInvContents;
         }
 
+        private static final PlayerDataSnapshot EMPTY_SNAPSHOT = new PlayerDataSnapshot(
+                -1,
+                -1,
+                -1,
+                -1,
+                null,
+                -1,
+                -1,
+                -1,
+                null,
+                null,
+                null
+        );
+
+        public boolean isEmptySnapshot() {
+            return this == EMPTY_SNAPSHOT;
+        }
+
         @Override
         public boolean equals(Object obj) {
             if (this == obj) return true;
@@ -217,7 +236,7 @@ public class SaveInventory {
             if (Double.compare(that.locY, locY) != 0) return false;
             if (Double.compare(that.locZ, locZ) != 0) return false;
             if (Float.compare(that.totalXp, totalXp) != 0) return false;
-            if (!worldName.equals(that.worldName)) return false;
+            if (!Objects.equals(worldName, that.worldName)) return false;
             if (!Arrays.equals(finalMainInvContents, that.finalMainInvContents)) return false;
             if (!Arrays.equals(finalMainInvArmor, that.finalMainInvArmor)) return false;
             if (!Arrays.equals(finalEnderInvContents, that.finalEnderInvContents)) return false;

--- a/src/main/java/me/danjono/inventoryrollback/listeners/EventLogs.java
+++ b/src/main/java/me/danjono/inventoryrollback/listeners/EventLogs.java
@@ -208,11 +208,13 @@ public class EventLogs implements Listener {
 			if (preSnapshot == null) {
 				saveInventory.snapshotAndSave(player.getInventory(), player.getEnderChest(), true);
 			} else {
+				// Remove the snapshot from the cache
+				this.inventoryCache.remove(uuid);
+				// Ensure we don't save the empty snapshot
+				if (preSnapshot.isEmptySnapshot()) return;
 				// Save the snapshot inventory instead of the current one. We apparently had an edit
 				// during the damage event.
 				saveInventory.save(preSnapshot, true);
-				// Remove the snapshot from the cache
-				this.inventoryCache.remove(uuid);
 			}
         }
     }


### PR DESCRIPTION
Fixes NPE that occurs when both `save-empty-inventories` and `allow-other-plugins-edit-death-inventory` are set to false and a player dies with an empty inventory

To avoid NPE in `ConcurrentHashMap` we can't simply add null check for snapshot. Doing so would cause `playerDeathHandle` to skip pre-death validation when inventories are empty

This change replaces null returns with a static empty snapshot, allow `deathPreSnapshots` to safely store the state while ensuring that empty inventories are correctly ignored across all saving logic without NPE

[EventLogs.java#L126](https://github.com/TechnicallyCoded/Inventory-Rollback-Plus/blob/dev/src/main/java/me/danjono/inventoryrollback/listeners/EventLogs.java#L126)

<details>
<summary>NPE stacktrace</summary>

```
[23:17:48 ERROR]: Could not pass event EntityDamageEvent to InventoryRollbackPlus v1.8.0
java.lang.NullPointerException
        at java.base/java.util.concurrent.ConcurrentHashMap.putVal(ConcurrentHashMap.java:1023) ~[?:?]
        at java.base/java.util.concurrent.ConcurrentHashMap.put(ConcurrentHashMap.java:1018) ~[?:?]
        at InventoryRollbackPlus-1.8.0.jar//me.danjono.inventoryrollback.listeners.EventLogs.playerPreDeath(EventLogs.java:126) ~[?:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:71) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.event.Event.callEvent(Event.java:46) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDamageEvent(CraftEventFactory.java:1190) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDamageEvent(CraftEventFactory.java:1180) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at org.bukkit.craftbukkit.event.CraftEventFactory.handleEntityDamageEvent(CraftEventFactory.java:1170) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at org.bukkit.craftbukkit.event.CraftEventFactory.handleEntityDamageEvent(CraftEventFactory.java:1071) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at org.bukkit.craftbukkit.event.CraftEventFactory.handleLivingEntityDamageEvent(CraftEventFactory.java:1234) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.world.entity.LivingEntity.handleEntityDamage(LivingEntity.java:2441) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.world.entity.LivingEntity.hurtServer(LivingEntity.java:1486) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.world.entity.player.Player.hurtServer(Player.java:756) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.server.level.ServerPlayer.hurtServer(ServerPlayer.java:1300) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.world.entity.LivingEntity.causeFallDamage(LivingEntity.java:2242) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.world.entity.player.Player.causeFallDamage(Player.java:1557) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.world.level.block.Block.fallOn(Block.java:523) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.world.entity.Entity.checkFallDamage(Entity.java:1947) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.world.entity.LivingEntity.checkFallDamage(LivingEntity.java:409) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.server.level.ServerPlayer.checkFallDamage(ServerPlayer.java:1767) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.world.entity.Entity.doCheckFallDamage(Entity.java:1936) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleMovePlayer(ServerGamePacketListenerImpl.java:1712) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.network.protocol.game.ServerboundMovePlayerPacket.handle(ServerboundMovePlayerPacket.java:62) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.network.protocol.game.ServerboundMovePlayerPacket$PosRot.handle(ServerboundMovePlayerPacket.java:137) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.network.PacketProcessor$ListenerAndPacket.handle(PacketProcessor.java:99) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.network.PacketProcessor.executeSinglePacket(PacketProcessor.java:33) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1504) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.server.MinecraftServer.recordTaskExecutionTimeWhileWaiting(MinecraftServer.java:1230) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1346) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:388) ~[paper-1.21.11.jar:1.21.11-113-6103cc7]
        at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
```

</details>