### PR TITLE
Fix NPE in playerPreDeath (#235)

### DIFF
--- a/src/main/java/me/danjono/inventoryrollback/listeners/EventLogs.java
+++ b/src/main/java/me/danjono/inventoryrollback/listeners/EventLogs.java
@@ -123,6 +123,9 @@ public class EventLogs implements Listener {
 		SaveInventory saveInventory = new SaveInventory(player, LogType.DEATH, event.getCause(), null);
 		SaveInventory.PlayerDataSnapshot snapshot = saveInventory.createSnapshot(player.getInventory(), player.getEnderChest());
 
+		// createSnapshot() returns null if the inventory is empty and saving empty inventories is disabled
+		if (snapshot == null) return;
+
 		this.inventoryCache.put(uuid, snapshot);
 	}
 


### PR DESCRIPTION
Fixes NullPointerException in playerPreDeath when snapshot is null.

Closes #235 